### PR TITLE
we should handle OPTIONS requests too (related to newer python libs?)

### DIFF
--- a/src/webserver.py
+++ b/src/webserver.py
@@ -2,10 +2,10 @@
 Basic web server / framework.
 """
 
-from SocketServer import ThreadingMixIn
 import BaseHTTPServer
-import urlparse
 import cgi
+import urlparse
+from SocketServer import ThreadingMixIn
 
 
 class HTTPError(Exception):
@@ -56,6 +56,14 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             headers=self.headers,
             environ={'REQUEST_METHOD': 'POST'})
         self._call(self.path.strip('/'), params={'form_values': form_values})
+
+    def do_OPTIONS(self):
+        self.send_response(200, "ok")
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.end_headers()
 
     def _parse(self, reqinfo):
         """


### PR DESCRIPTION
hij deed wat auto-formatting (nergens voor nodig, dat mag je weghalen) - maar OPTIONS request gaf:

```
501  Unsupported method ('OPTIONS')
```
blijkbaar moet je dat bij nieuwere versies van BaseHTTPServer verplicht implementeren?